### PR TITLE
Add tab and carriage return whitespace handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ fn add_char_into_object(
                 *sts = ObjectStatus::Colon { key: key.clone() };
             }
         }
-        (Value::Object(_obj), ObjectStatus::Colon { .. }, ' ' | '\n') => {}
+        (Value::Object(_obj), ObjectStatus::Colon { .. }, ' ' | '\n' | '\t' | '\r') => {}
         (Value::Object(ref mut obj), sts @ ObjectStatus::Colon { .. }, '"') => {
             if let ObjectStatus::Colon { key } = sts.clone() {
                 *sts = ObjectStatus::ValueQuoteOpen { key: key.clone() };
@@ -298,6 +298,7 @@ fn add_char_into_object(
                 *sts = ObjectStatus::Closed;
             }
         }
+        (Value::Object(_obj), ObjectStatus::ValueScalar { .. }, ' ' | '\n' | '\t' | '\r') => {}
         (
             Value::Object(_obj),
             ObjectStatus::ValueScalar {
@@ -318,7 +319,7 @@ fn add_char_into_object(
             *sts = ObjectStatus::Closed;
         }
         // ------ white spaces ------
-        (_, _, ' ' | '\n') => {}
+        (_, _, ' ' | '\n' | '\t' | '\r') => {}
         (_val, st, c) => {
             return Err(format!("Invalid character {} status: {:?}", c, st));
         }
@@ -501,4 +502,6 @@ param_test! {
     zero: r#"0"#, Value::Number(0.into())
     float: r#"123.456"#, Value::Number(serde_json::Number::from_f64(123.456).unwrap())
     negative_float: r#"-123.456"#, Value::Number(serde_json::Number::from_f64(-123.456).unwrap())
+    tab_whitespace_number: "\t123\t", Value::Number(123.into())
+    carriage_return_whitespace_number: "\r123\r", Value::Number(123.into())
 }


### PR DESCRIPTION
## Summary
- handle tab and carriage return as whitespace
- support whitespace after scalar values
- test tab and carriage return whitespace via `param_test`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684106c5edc48324b2c5cb14702ba41b