### PR TITLE
Fix cargo publish trigger

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,7 @@ jobs:
         run: echo "The version of the Rust library is ${{ steps.get_version.outputs.LIB_LOCAL_VERSION }}"
   
   cargo-push:
+    if: github.event_name == 'push'
     needs: test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- only publish crates when there's a push to `main`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68435a6b210c8324a1d9ccb287ec8238