### PR TITLE
Publish crates on main branch push

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,6 +69,7 @@ jobs:
   cargo-push:
     needs: [test, property-tests, clippy]
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Add condition to `cargo-push` job to only publish crates on push to main.