### PR TITLE
Implement parser limits and error handling improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project is built with [Rust](https://www.rust-lang.org/), and you'll need `
 ## Usage
 
 The simplest way to use this library is to use the `parse_stream` function, which takes a string slice and returns a `Result` containing a `serde_json::Value` if successful.
+If you need to guard against malicious input sizes or excessive nesting, use `parse_stream_with_limits` to specify optional limits on input length and nesting depth.
 Here's an example:
 
 ```rust

--- a/tests/limit_tests.rs
+++ b/tests/limit_tests.rs
@@ -1,0 +1,15 @@
+use json_stream_parser::parse_stream_with_limits;
+
+#[test]
+fn depth_limit_exceeded() {
+    let json = "[[[1]]]";
+    let result = parse_stream_with_limits(json, Some(2), None);
+    assert!(result.is_err());
+}
+
+#[test]
+fn length_limit_exceeded() {
+    let json = "[1,2,3]";
+    let result = parse_stream_with_limits(json, None, Some(5));
+    assert!(result.is_err());
+}

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -1,7 +1,7 @@
+use json_stream_parser::{parse_stream, JsonStreamParser};
 use proptest::prelude::*;
 use proptest::string::string_regex;
-use json_stream_parser::{parse_stream, JsonStreamParser};
-use serde_json::{Value, Map};
+use serde_json::{Map, Value};
 use std::collections::BTreeMap;
 
 fn json_number() -> impl Strategy<Value = serde_json::Number> {
@@ -13,7 +13,9 @@ fn json_value() -> impl Strategy<Value = Value> {
         Just(Value::Null),
         any::<bool>().prop_map(Value::Bool),
         json_number().prop_map(Value::Number),
-        string_regex("[a-zA-Z0-9]{0,20}").unwrap().prop_map(Value::String),
+        string_regex("[a-zA-Z0-9]{0,20}")
+            .unwrap()
+            .prop_map(Value::String),
     ];
     leaf.prop_recursive(3, 8, 3, |inner| {
         prop_oneof![


### PR DESCRIPTION
## Summary
- add optional input length and nesting limits via `parse_stream_with_limits`
- track processed characters and enforce limits in `JsonStreamParser`
- provide better error messages when indexing or parsing numbers
- document new limited parsing API in README
- test depth and length limits

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --tests`

------
https://chatgpt.com/codex/tasks/task_e_686b5999be348324aaa497f454290cf7