### PR TITLE
Bump crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "json-stream-parser"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "proptest",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-stream-parser"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.65.0"
 description = "A JSON parser that is capable of parsing incomplete JSON strings that are streamed in."


### PR DESCRIPTION
## Summary
- update package version to 0.1.5
- refresh Cargo.lock to use available dependencies

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686b62e05c6c832490cf1f5d291ec1e6